### PR TITLE
Fix esdoc config

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -11,13 +11,15 @@
           "index": "./README.md",
           "asset": "./src/docs/assets",
           "files": [
-            "./src/docs/NodeAndClientTypes.md",
-            "./src/docs/CryptographicPrimitives.md",
-            "./src/docs/AccountTypes.md",
-            "./src/docs/TransactionTypes.md",
-            "./src/docs/DataStructures.md"
-            "./src/docs/SupplyAndRewards.md"
-            "./src/docs/Constants.md"
+            "./src/docs/transactions.md",
+            "./src/docs/block.md",
+            "./src/docs/accounts-and-contracts.md",
+            "./src/docs/account-tree.md",
+            "./src/docs/primitives.md",
+            "./src/docs/messages.md",
+            "./src/docs/constants.md",
+            "./src/docs/nodes-and-clients.md",
+            "./src/docs/supply-and-reward.md"
           ]
         }
       }


### PR DESCRIPTION
This commit fixes the esdoc config file so that the doc can be built in case we may want to use that in the future to integrate this doc with the auto-generated docs from the [core repo](https://github.com/nimiq-network/core) (we would need to make some cosmetic improvements, but that can be done later if we decide to go this route).

Also, this doesn't interferes with using this repo directly from github as the documentation (which makes a lot of sense too and is more simple, 😃 ).