### PR TITLE
Fix 404 links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ High level concepts used in and underlying Nimiq.
 ## Further Resources
 Further resources to get an overview of the Nimiq project and ecosystem:
 * [API Documentation](https://github.com/nimiq-network/core/blob/master/dist/API_DOCUMENTATION.md)
-* [Browser Miner](https://nimiq.com/miner) and [Browser Wallet](https://nimiq.com/wallet)
+* [Browser Miner](https://miner.nimiq.com) and [Browser Wallet](https://safe.nimiq.com)
 * [Contributing Guidelines](https://github.com/nimiq-network/core/blob/master/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/nimiq-network/core/blob/master/.github/CODE_OF_CONDUCT.md)
 * This project is released under the [Apache License 2.0](https://github.com/nimiq-network/core/blob/master/LICENSE.md)
 


### PR DESCRIPTION
Fixes dead links in README, as nimiq.com/wallet is now safe.nimiq.com, and the miner has moved to miner.nimiq.com