### PR TITLE
Add register deviceLabel

### DIFF
--- a/chapters/pool-protocol.md
+++ b/chapters/pool-protocol.md
@@ -41,6 +41,7 @@ Send by client directly after connecting to the server.
 | `mode`    | string, `nano` or `smart` | The mode this client uses |
 | `address` | string | The address (in IBAN-style format) that should be rewarded for the miner actions |
 | `deviceId` | number, uint32 | The clients device id. This ID should be unique for the device and stored, such that it stays the same after restarts |
+| `deviceLabel` | string, optional | A non-unique device label that can be used to group devices. Max length of 64 characters |
 | `genesisHash` | string | Base64 encoded hash of the genesis block used by the client |
 
 ##### Example
@@ -51,6 +52,7 @@ Send by client directly after connecting to the server.
     "mode": "nano",
     "address": "NQ07 0000 0000 0000 0000 0000 0000 0000 0000",
     "deviceId": 12345678,
+    "deviceLabel": "Skylake Miner",
     "genesisHash": "Jkqvik+YKKdsVQY12geOtGYwahifzANxC+6fZJyGnRI="
 }
 ```


### PR DESCRIPTION
Adds an optional `deviceLabel` field to `REGISTER`.
See:
https://github.com/nimiq-network/core/pull/395
https://github.com/nimiq-network/mining-pool/pull/12