### PR TITLE
Fix spelling mistakes in `verify.md`

### DIFF
--- a/chapters/verify.md
+++ b/chapters/verify.md
@@ -69,7 +69,7 @@ Rules
 * Verify each transaction
     * Is ordered correctly, cf. [transaction order](#transaction-order)
     * Is valid
-* And each accountd
+* And each account
     * Is ordered
     * Is to be pruned
 


### PR DESCRIPTION
Fixed two small spelling mistakes in `verify.md`:

 * Duplicate `will` in *Blockchain verification* section.
 * Changed `accountd` to `account` in *Verify each transaction*