### PR TITLE
Update German translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This developer reference contains:
 * [Data Schemas](#data-schemas)
 * [High Level Concepts and Architecture](#high-level-concepts)
 
-This documentation is also [available in German](https://github.com/terorie/nimiq-developer-reference-german) as a community effort by Terorie.
+This documentation is also [available in German](https://terorie.github.io/nimiq-developer-reference-german/) as a community effort by Terorie.
 
 ## Data Schemas
 


### PR DESCRIPTION
I noticed my translation got added to the README :)

It points to the GitHub repo (https://github.com/terorie/nimiq-developer-reference-german)

Maybe it's better to point it to the website 🤔
https://terorie.github.io/nimiq-developer-reference-german/